### PR TITLE
Optional padding

### DIFF
--- a/mrblib/base32.rb
+++ b/mrblib/base32.rb
@@ -39,6 +39,7 @@ module Base32
   def self.decode(s)
     pad_chr_num = 0
     keys = []
+    s += '=' * (s.bytesize % 8 == 0 ? 0 : 8 - s.bytesize % 8)
     s.bytesize.times do |i|
       if s[i] == '='
         pad_chr_num += 1

--- a/mrblib/base32.rb
+++ b/mrblib/base32.rb
@@ -1,7 +1,7 @@
 module Base32
   BASE32_TBL = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
 
-  def self.encode(s)
+  def self.encode(s, padding = true)
     s_bin = s.bytes
     pad_chr_num = 5 - s_bin.length % 5
     if 0 < pad_chr_num && pad_chr_num < 5
@@ -22,7 +22,8 @@ module Base32
 
     if 0 < pad_chr_num && pad_chr_num < 5
       n = ((8 * pad_chr_num) / 5).floor
-      base32 = base32.slice(0, base32.length - n) + '=' * n
+      base32 = base32.slice(0, base32.length - n)
+      base32 += '=' * n if padding
     end
 
     base32

--- a/test/base32.rb
+++ b/test/base32.rb
@@ -39,3 +39,17 @@ assert('Base32.decode') do
     assert_equal Base32.decode(t[:data]), t[:expect]
   end
 end
+
+assert('Base32.decode even if padding is missing/incomplete') do
+  test = [
+   {:data => '',           :expect => '' },
+   {:data => 'ME',         :expect => 'a'},
+   {:data => 'MFRGGZDF',   :expect => 'abcde'},
+   {:data => 'MFRGGZDFMY', :expect => 'abcdef'},
+   {:data => 'AA',         :expect => "\x0"},
+  ]
+
+  test.each do |t|
+    assert_equal Base32.decode(t[:data]), t[:expect]
+  end
+end

--- a/test/base32.rb
+++ b/test/base32.rb
@@ -12,6 +12,20 @@ assert('Base32.encode') do
   end
 end
 
+assert('Base32.encode without padding') do
+  test = [
+   {:data => '',       :expect => ''},
+   {:data => 'a',      :expect => 'ME'},
+   {:data => 'abcde',  :expect => 'MFRGGZDF'},
+   {:data => 'abcdef', :expect => 'MFRGGZDFMY'},
+   {:data => "\x0",    :expect => 'AA'},
+  ]
+
+  test.each do |t|
+    assert_equal Base32.encode(t[:data], false), t[:expect]
+  end
+end
+
 assert('Base32.decode') do
   test = [
    {:data => '',                 :expect => '' },

--- a/test/base32.rb
+++ b/test/base32.rb
@@ -8,7 +8,7 @@ assert('Base32.encode') do
   ]
 
   test.each do |t|
-    assertion_string Base32.encode(t[:data]), t[:expect]
+    assert_equal Base32.encode(t[:data]), t[:expect]
   end
 end
 
@@ -22,6 +22,6 @@ assert('Base32.decode') do
   ]
 
   test.each do |t|
-    assertion_string Base32.decode(t[:data]), t[:expect]
+    assert_equal Base32.decode(t[:data]), t[:expect]
   end
 end


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc4648#section-3.2

> Implementations MUST include appropriate pad characters at the end of encoded data unless the specification referring to this document explicitly states otherwise.

The main change introduced by this pull request is making padding optional (but applied unless explicitly excluded). I've also tweaked `Base32.decode` to try to "recover" from damaged/incomplete strings.